### PR TITLE
[Add] Link to online documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,15 +1,12 @@
 .. These are examples of badges you might want to add to your README:
    please update the URLs accordingly
 
-    .. image:: https://api.cirrus-ci.com/github/<USER>/misosoupy.svg?branch=main
-        :alt: Built Status
-        :target: https://cirrus-ci.com/github/<USER>/misosoupy
-    .. image:: https://readthedocs.org/projects/misosoupy/badge/?version=latest
-        :alt: ReadTheDocs
-        :target: https://misosoupy.readthedocs.io/en/stable/
-    .. image:: https://img.shields.io/coveralls/github/<USER>/misosoupy/main.svg
-        :alt: Coveralls
-        :target: https://coveralls.io/r/<USER>/misosoupy
+.. image:: https://readthedocs.org/projects/misosoupy/badge/?version=latest
+    :alt: ReadTheDocs
+    :target: https://misosoupy.readthedocs.io/en/stable/
+.. image:: https://img.shields.io/coveralls/github/miso-sound/misosoupy/main.svg
+    :alt: Coveralls
+    :target: https://coveralls.io/r/miso-sound/misosoupy
     .. image:: https://img.shields.io/pypi/v/misosoupy.svg
         :alt: PyPI-Server
         :target: https://pypi.org/project/misosoupy/
@@ -19,14 +16,6 @@
     .. image:: https://pepy.tech/badge/misosoupy/month
         :alt: Monthly Downloads
         :target: https://pepy.tech/project/misosoupy
-    .. image:: https://img.shields.io/twitter/url/http/shields.io.svg?style=social&label=Twitter
-        :alt: Twitter
-        :target: https://twitter.com/misosoupy
-
-.. image:: https://img.shields.io/badge/-PyScaffold-005CA0?logo=pyscaffold
-    :alt: Project generated with PyScaffold
-    :target: https://pyscaffold.org/
-
 |
 
 =========
@@ -39,8 +28,6 @@ MisoSOUPy
 
 A Python package to customize stimuli for experiments on misophonia based on participants' self-reported triggers.
 
-
-.. _pyscaffold-notes:
 
 Making Changes & Contributing
 =============================
@@ -56,12 +43,4 @@ It is a good idea to update the hooks to the latest version::
 
     pre-commit autoupdate
 
-Don't forget to tell your contributors to also install and use pre-commit.
-
 .. _pre-commit: https://pre-commit.com/
-
-Note
-====
-
-This project has been set up using PyScaffold 4.5. For details and usage
-information on PyScaffold see https://pyscaffold.org/.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,25 +4,6 @@ misosoupy
 
 This is the documentation of **misosoupy**.
 
-.. note::
-
-    This is the main page of your project's `Sphinx`_ documentation.
-    It is formatted in `reStructuredText`_. Add additional pages
-    by creating rst-files in ``docs`` and adding them to the `toctree`_ below.
-    Use then `references`_ in order to link them from this page, e.g.
-    :ref:`authors` and :ref:`changes`.
-
-    It is also possible to refer to the documentation of other Python packages
-    with the `Python domain syntax`_. By default you can reference the
-    documentation of `Sphinx`_, `Python`_, `NumPy`_, `SciPy`_, `matplotlib`_,
-    `Pandas`_, `Scikit-Learn`_. You can add more by extending the
-    ``intersphinx_mapping`` in your Sphinx's ``conf.py``.
-
-    The pretty useful extension `autodoc`_ is activated by default and lets
-    you include documentation from docstrings. Docstrings can be written in
-    `Google style`_ (recommended!), `NumPy style`_ and `classical style`_.
-
-
 Contents
 ========
 


### PR DESCRIPTION
This PR adds a link to the readthedocs page. Note that it points to the stable version which doesn't exist yet, but you can see the latest version here: https://misosoupy.readthedocs.io/en/latest/