### PR TITLE
add config file to input step selections and screen parameters

### DIFF
--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -12,12 +12,14 @@ step_import_sound_list = True
 # Default = True
 step_select_sound_list = True
 
-# Request participants select their most triggering sounds (Default = True)
+# Request participants select their most triggering sounds. Step_select_sound_list 
+# must be True for this option to be True. (Default = True)
 step_select_trigger = True
 
 # Request participants select their least triggering (or neutral) sounds. 
 # If triggering sounds are selected first, these options will remain in the 
-# list but appear grayed out. (Default = True)
+# list but appear grayed out. Step_select_sound_list must be True for this option
+# to be True. (Default = True)
 step_select_neutral = True
 
 #------------------------------------------------------------------------------------------
@@ -28,10 +30,12 @@ step_select_neutral = True
 # Default = True
 step_refine_sound_list = True
 
-# Request participants refine their most triggering sound selections (Default = True)
+# Request participants refine their most triggering sound selections. Step_refine_sound_list 
+# must be True for this option to be True. (Default = True)
 step_refine_trigger = True
 
-# Request participants refine their least triggering (neutral) sound selections (Default = True)
+# Request participants refine their least triggering (neutral) sound selections. Step_refine_sound_list 
+# must be True for this option to be True. (Default = True)
 step_refine_neutral = True
 
 #------------------------------------------------------------------------------------------

--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -86,7 +86,7 @@ num_items_per_column = 10
 # If fewer labels than this number are selected, participants see an error screen
 # and must restart. If step_refine_sound_list = True, participants will also rank
 # order this number of sounds. Default = 5.
-num_items_to_select = 4
+num_items_to_select = 5
 
 # Length of time (in seconds) to pause on each page before continue button appears. Default = 2.
 pause_time = 2

--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -14,7 +14,7 @@ step_select_sound_list = True
 
 # Request participants select their most triggering sounds. Step_select_sound_list 
 # must be True for this option to be True. (Default = True)
-step_select_trigger = False
+step_select_trigger = True
 
 # Request participants select their least triggering (or neutral) sounds. 
 # If triggering sounds are selected first, these options will remain in the 
@@ -32,7 +32,7 @@ step_refine_sound_list = True
 
 # Request participants refine their most triggering sound selections. Step_refine_sound_list 
 # must be True for this option to be True. (Default = True)
-step_refine_trigger = False
+step_refine_trigger = True
 
 # Request participants refine their least triggering (neutral) sound selections. Step_refine_sound_list 
 # must be True for this option to be True. (Default = True)

--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -82,5 +82,11 @@ num_columns_per_page = 2
 # Number of sound labels to display in each column. Default = 10.
 num_items_per_column = 10
 
+# Minimum number of sound labels participants must select in each sound category.
+# If fewer labels than this number are selected, participants see an error screen
+# and must restart. If step_refine_sound_list = True, participants will also rank
+# order this number of sounds. Default = 5.
+num_items_to_select = 4
+
 # Length of time (in seconds) to pause on each page before continue button appears. Default = 2.
 pause_time = 2

--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -1,0 +1,82 @@
+[STEPS]
+# Queries sound list or directory for file names and labels. Outputs total number of sounds, 
+# total number of unique labels, and first 10 labels as examples. Does not require psychopy.
+# Default = True [REQUIRED]
+step_import_sound_list = True
+
+#------------------------------------------------------------------------------------------
+
+# Presents sound labels on screen with checkboxes, across multiple pages (if necessary). 
+# Participants click which sounds they experience as triggering/neutral/etc. At least 5 
+# labels must be selected, or selection starts over. Requires psychopy.
+# Default = True
+step_select_sound_list = True
+
+# Request participants select their most triggering sounds (Default = True)
+step_select_trigger = True
+
+# Request participants select their least triggering (or neutral) sounds. 
+# If triggering sounds are selected first, these options will remain in the 
+# list but appear grayed out. (Default = True)
+step_select_neutral = True
+
+#------------------------------------------------------------------------------------------
+
+# Re-presents only the sound labels selected by the participant, with instructions to rank 
+# order the top 5 sounds. Useful if more labels are selected than can reasonably be presented 
+# in an experiment. Requires psychopy.
+# Default = True
+step_refine_sound_list = True
+
+# Request participants refine their most triggering sound selections (Default = True)
+step_refine_trigger = True
+
+# Request participants refine their least triggering (neutral) sound selections (Default = True)
+step_refine_neutral = True
+
+#------------------------------------------------------------------------------------------
+
+# Creates a text file listing sound labels and associated files for each participant selection. 
+# If refinement step occurs, an additional column lists the rank order for each label.
+# Text file is saved using participant ID in folder Sound_Selections. Does not require psychopy.
+# Default = True
+step_organize_sounds = True
+
+############################################################################################
+
+[SCREEN]
+# Whether psychopy opens full screen (True) or windowed (False). Default = True.
+setup_full_screen_choice = True
+
+# If multiple monitors, which monitor to display pysychopy on. Default = 0 (primary)
+setup_which_screen = 0
+
+# Screen size (not crucial - psychopy will use actual size, if different from listed)
+setup_screen_size = [1920, 1080]
+
+# Background color of screen. Default = lightgray.
+setup_screen_color = lightgray
+
+# Text color of instructions, sound labels, etc. Default = black.
+setup_text_color = black
+
+# Shape color of continue button. Default = gray.
+setup_continue_shape_color = gray
+
+# Outline color of buttons and checkbox squares. Default = black.
+setup_shape_line_color = black
+
+# Shape size of checkbox squares (including outline). Default = 0.12
+setup_square_outline_size = 0.12
+
+# Shape size of checkbox squares (not including outline). Default = 0.1
+setup_square_size = 0.1
+
+# Number of columns in which to display list of sound labels. Default = 2.
+num_columns_per_page = 2
+
+# Number of sound labels to display in each column. Default = 10.
+num_items_per_column = 10
+
+# Length of time (in seconds) to pause on each page before continue button appears. Default = 2.
+pause_time = 2

--- a/src/misosoupy/config.ini
+++ b/src/misosoupy/config.ini
@@ -14,7 +14,7 @@ step_select_sound_list = True
 
 # Request participants select their most triggering sounds. Step_select_sound_list 
 # must be True for this option to be True. (Default = True)
-step_select_trigger = True
+step_select_trigger = False
 
 # Request participants select their least triggering (or neutral) sounds. 
 # If triggering sounds are selected first, these options will remain in the 
@@ -32,7 +32,7 @@ step_refine_sound_list = True
 
 # Request participants refine their most triggering sound selections. Step_refine_sound_list 
 # must be True for this option to be True. (Default = True)
-step_refine_trigger = True
+step_refine_trigger = False
 
 # Request participants refine their least triggering (neutral) sound selections. Step_refine_sound_list 
 # must be True for this option to be True. (Default = True)

--- a/src/misosoupy/psychopy_exit_out.py
+++ b/src/misosoupy/psychopy_exit_out.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+@author: hhanse
+"""
+
+# --- Import packages ---
+from psychopy import core, logging
+
+def function_exit_out(win):
+    """Safely exit out of presentation, closing window and flushing log."""
+
+    logging.flush()
+    win.close()
+    core.quit()

--- a/src/misosoupy/psychopy_present_instructions.py
+++ b/src/misosoupy/psychopy_present_instructions.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+@author: hhanse
+"""
+
+# --- Import packages ---
+import os 
+from psychopy import core, event, visual
+
+# Import config file and screen parameters
+import psychopy_exit_out
+import setup_misosoupy
+config_path = setup_misosoupy.get_home_dir() + os.sep + 'config.ini'
+[setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
+
+setup_text_color = setup_screen.get('setup_text_color')
+setup_screen_color = setup_screen.get('setup_screen_color')
+setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
+setup_shape_line_color = setup_screen.get('setup_shape_line_color')
+
+def function_present_instructions(win, instruction_text, wait_time):
+        """Present instruction text onscreen using PsychoPy.
+
+        Parameters
+        ----------
+        instruction_text : str
+            Text to display.
+        wait_time : int
+            Time (in seconds) to pause before CONTINUE button is displayed.
+        """
+
+        # Prep instructions
+        stim_text_instruction1 = visual.TextStim(
+            win,
+            text=instruction_text,
+            pos=(0, 0),
+            color=setup_text_color,
+            height=0.09,
+            wrapWidth=6,
+        )
+        # Prep Continue Button
+        stim_text_continue = visual.TextStim(
+            win,
+            text="Click here to continue",
+            pos=(0.7, -0.85),
+            color=setup_screen_color,
+            height=0.08,
+        )
+        stim_shape_exit = visual.ShapeStim(
+            win,
+            vertices=((-0.5, -0.3), (-0.5, 0.3), (0.5, 0.3), (0.5, -0.3)),
+            pos=(1, 1),
+            size=(0.35, 0.35),
+            opacity=100,
+            fillColor=setup_screen_color,
+            lineColor=None,
+            lineWidth=4.0,
+            name="stim_shape_exit",
+        )
+        stim_shape_continue = stim_shape_exit
+
+        mouse = event.Mouse(win=win, visible=True)
+        mouse.clickReset()
+        event.clearEvents()
+
+        continue_chosen = False
+        stim_text_instruction1.draw()
+        stim_shape_continue.draw()
+        stim_text_continue.draw()
+        stim_shape_exit.draw()
+        win.flip()
+        core.wait(wait_time)
+        while continue_chosen is False:
+            stim_text_instruction1.draw()
+            stim_shape_continue.draw()
+            stim_text_continue.draw()
+            stim_shape_exit.draw()
+            win.flip()
+
+            if mouse.isPressedIn(stim_shape_exit):
+                psychopy_exit_out.function_exit_out(win)
+
+            # Make Continue Button visible after 3 seconds
+            stim_shape_continue = visual.ShapeStim(
+                win,
+                vertices=((-0.5, -0.3), (-0.5, 0.3), (0.5, 0.3), (0.5, -0.3)),
+                pos=(0.7, -0.85),
+                size=(0.45, 0.2),
+                opacity=100,
+                fillColor=setup_continue_shape_color,
+                lineColor=setup_shape_line_color,
+                lineWidth=4.0,
+                name="stim_shape_continue",
+            )
+            stim_text_continue = visual.TextStim(
+                win,
+                text="CONTINUE",
+                pos=(0.7, -0.85),
+                color=setup_text_color,
+                height=0.08,
+            )
+
+            if mouse.isPressedIn(stim_shape_continue):
+                stim_text_instruction1.draw()
+                stim_shape_continue.draw()
+                stim_text_continue.draw()
+                win.flip()
+                continue_chosen = True

--- a/src/misosoupy/psychopy_present_item_list.py
+++ b/src/misosoupy/psychopy_present_item_list.py
@@ -8,8 +8,25 @@ from __future__ import division
 
 import time
 
+import os
+
 # --- Import packages ---
 from psychopy import core, event, logging, visual
+
+# Import config file and screen parameters
+import setup_misosoupy
+config_path = setup_misosoupy.get_home_dir() + os.sep + 'config.ini'
+[setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
+
+num_columns_per_page = setup_screen.get('num_columns_per_page')
+num_items_per_column = setup_screen.get('num_items_per_column')
+setup_square_outline_size = setup_screen.get('setup_square_outline_size')
+setup_square_size = setup_screen.get('setup_square_size')
+setup_text_color = setup_screen.get('setup_text_color')
+setup_screen_color = setup_screen.get('setup_screen_color')
+setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
+setup_shape_line_color = setup_screen.get('setup_shape_line_color')
+pause_time = setup_screen.get('pause_time')
 
 
 def function_exit_out(win):
@@ -22,20 +39,11 @@ def function_exit_out(win):
 
 def function_present_item_list(
     unique_sound_labels,
-    num_columns_per_page,
-    num_items_per_column,
     num_items_per_page,
     mean_length,
     setup_item_height,
-    setup_square_outline_size,
-    setup_square_size,
-    setup_text_color,
-    setup_screen_color,
-    setup_continue_shape_color,
-    setup_shape_line_color,
     win,
     page_num,
-    pause_time,
     instructions1,
     instructions2,
     instructions2_color,
@@ -56,34 +64,16 @@ def function_present_item_list(
     ----------
     unique_sound_labels : np.array
         List of sound labels to present onscreen, defined in import_sound_list.py
-    num_columns_per_page : int
-        Default is 2.
-    num_items_per_column : int
-        Default is 10.
     num_items_per_page : int
         Default is 20.
     mean_length : int
         Average number of characters comprising the sound labels. Used to determine font size.
     setup_item_height : int
         Font height. Default is 0.085.
-    setup_square_outline_size : int
-        Default is 0.12.
-    setup_square_size : int
-        Default is 0.1.
-    setup_text_color : str
-        Default is "black".
-    setup_screen_color : str
-        Default is "lightgray".
-    setup_continue_shape_color : str
-        Default is "gray".
-    setup_shape_line_color : str
-        Default is "black".
     win : visual.Window object
         Screen set up.
     page_num : int
         Current page number.
-    pause_time : int
-        How long to pause on each page before continue button appears. Default is 2 (seconds).
     instructions1 : str
         Task instructions, written in black.
     instructions2 : str

--- a/src/misosoupy/psychopy_present_item_list.py
+++ b/src/misosoupy/psychopy_present_item_list.py
@@ -14,6 +14,7 @@ import os
 from psychopy import core, event, logging, visual
 
 # Import config file and screen parameters
+import psychopy_exit_out
 import setup_misosoupy
 config_path = setup_misosoupy.get_home_dir() + os.sep + 'config.ini'
 [setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
@@ -27,14 +28,6 @@ setup_screen_color = setup_screen.get('setup_screen_color')
 setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
 setup_shape_line_color = setup_screen.get('setup_shape_line_color')
 pause_time = setup_screen.get('pause_time')
-
-
-def function_exit_out(win):
-    """Safely exit out of presentation, closing window and flushing log."""
-
-    logging.flush()
-    win.close()
-    core.quit()
 
 
 def function_present_item_list(
@@ -337,7 +330,7 @@ def function_present_item_list(
         win.flip()
 
         if mouse.isPressedIn(stim_shape_exit):
-            function_exit_out(win)
+            psychopy_exit_out.function_exit_out(win)
 
         # Check for checkbox clicks
         for s in range(0, len(all_boxes)):

--- a/src/misosoupy/psychopy_refine_item_list.py
+++ b/src/misosoupy/psychopy_refine_item_list.py
@@ -49,8 +49,9 @@ def function_present_refined_item_list(
     ----------
     num_items_to_select: int
         Number of sounds necessary for experiment, i.e., up to how many sounds participants rank.
-        Defined in config.ini, updated in misosoupy.py if multiple categories are selected for 
-        (e.g., trigger and neutral) and there are fewer than num_items_to_select options available.
+        Defined in config.ini (default = 5), updated in misosoupy.py if multiple categories are 
+        selected for (e.g., trigger and neutral) and there are fewer than num_items_to_select 
+        options available.
     mean_length : int
         Average number of characters comprising the sound labels. Used to determine font size.
     setup_item_height : int

--- a/src/misosoupy/psychopy_refine_item_list.py
+++ b/src/misosoupy/psychopy_refine_item_list.py
@@ -11,9 +11,22 @@ import math
 
 import numpy as np
 
+import os
+
 # --- Import packages ---
 from psychopy import core, event, logging, visual
 
+# Import config file and screen parameters
+import setup_misosoupy
+config_path = setup_misosoupy.get_home_dir() + os.sep + 'config.ini'
+[setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
+
+setup_square_outline_size = setup_screen.get('setup_square_outline_size')
+setup_square_size = setup_screen.get('setup_square_size')
+setup_text_color = setup_screen.get('setup_text_color')
+setup_screen_color = setup_screen.get('setup_screen_color')
+setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
+setup_shape_line_color = setup_screen.get('setup_shape_line_color')
 
 def function_exit_out(win):
     """Safely exit out of presentation, closing window and flushing log."""
@@ -26,12 +39,6 @@ def function_exit_out(win):
 def function_present_refined_item_list(
     mean_length,
     setup_item_height,
-    setup_square_outline_size,
-    setup_square_size,
-    setup_text_color,
-    setup_screen_color,
-    setup_continue_shape_color,
-    setup_shape_line_color,
     win,
     items,
     instructions1,
@@ -49,18 +56,6 @@ def function_present_refined_item_list(
         Average number of characters comprising the sound labels. Used to determine font size.
     setup_item_height : int
         Font height. Default is 0.085.
-    setup_square_outline_size : int
-        Default is 0.12.
-    setup_square_size : int
-        Default is 0.1.
-    setup_text_color : str
-        Default is "black".
-    setup_screen_color : str
-        Default is "lightgray".
-    setup_continue_shape_color : str
-        Default is "gray".
-    setup_shape_line_color : str
-        Default is "black".
     win : visual.Window object
         Screen set up.
     items : list

--- a/src/misosoupy/psychopy_refine_item_list.py
+++ b/src/misosoupy/psychopy_refine_item_list.py
@@ -28,9 +28,10 @@ setup_text_color = setup_screen.get('setup_text_color')
 setup_screen_color = setup_screen.get('setup_screen_color')
 setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
 setup_shape_line_color = setup_screen.get('setup_shape_line_color')
-num_items_to_select = setup_screen.get('num_items_to_select')
+#num_items_to_select = setup_screen.get('num_items_to_select')
 
 def function_present_refined_item_list(
+    num_items_to_select,
     mean_length,
     setup_item_height,
     win,
@@ -46,6 +47,10 @@ def function_present_refined_item_list(
 
     Parameters
     ----------
+    num_items_to_select: int
+        Number of sounds necessary for experiment, i.e., up to how many sounds participants rank.
+        Defined in config.ini, updated in misosoupy.py if multiple categories are selected for 
+        (e.g., trigger and neutral) and there are fewer than num_items_to_select options available.
     mean_length : int
         Average number of characters comprising the sound labels. Used to determine font size.
     setup_item_height : int

--- a/src/misosoupy/psychopy_refine_item_list.py
+++ b/src/misosoupy/psychopy_refine_item_list.py
@@ -17,6 +17,7 @@ import os
 from psychopy import core, event, logging, visual
 
 # Import config file and screen parameters
+import psychopy_exit_out
 import setup_misosoupy
 config_path = setup_misosoupy.get_home_dir() + os.sep + 'config.ini'
 [setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
@@ -27,14 +28,6 @@ setup_text_color = setup_screen.get('setup_text_color')
 setup_screen_color = setup_screen.get('setup_screen_color')
 setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
 setup_shape_line_color = setup_screen.get('setup_shape_line_color')
-
-def function_exit_out(win):
-    """Safely exit out of presentation, closing window and flushing log."""
-
-    logging.flush()
-    win.close()
-    core.quit()
-
 
 def function_present_refined_item_list(
     mean_length,
@@ -271,7 +264,7 @@ def function_present_refined_item_list(
         win.flip()
 
         if mouse.isPressedIn(stim_shape_exit):
-            function_exit_out()
+            psychopy_exit_out.function_exit_out(win)
 
         # Check for checkbox clicks
         for s in range(0, len(all_boxes)):

--- a/src/misosoupy/psychopy_refine_item_list.py
+++ b/src/misosoupy/psychopy_refine_item_list.py
@@ -28,6 +28,7 @@ setup_text_color = setup_screen.get('setup_text_color')
 setup_screen_color = setup_screen.get('setup_screen_color')
 setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
 setup_shape_line_color = setup_screen.get('setup_shape_line_color')
+num_items_to_select = setup_screen.get('num_items_to_select')
 
 def function_present_refined_item_list(
     mean_length,
@@ -278,7 +279,7 @@ def function_present_refined_item_list(
                         items_chosen[s] = 1
                         all_choices[s].pos = all_square_position_values[s]
                         all_choices[s].text = str(current_rank)
-                        if current_rank == 5:
+                        if current_rank == num_items_to_select:
                             all_ranks_chosen = True
                         else:
                             current_rank += 1

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -507,7 +507,7 @@ if (setup_steps.get('step_organize_sounds') is True):
             os.remove(file_name)
 
     with open(file_name, "w") as textfile:
-        if step_refine_sound_list:
+        if (setup_steps.get('step_refine_sound_list') is True):
             print(
                 "SOUND_TYPE\t",
                 "RANK\t",
@@ -525,7 +525,7 @@ if (setup_steps.get('step_organize_sounds') is True):
         for iMost in most_triggering_list:
             current_path = all_sound_files[np.char.find(all_sound_labels, iMost) >= 0]
             with open(file_name, "a") as textfile:
-                if step_refine_trigger:
+                if (setup_steps.get('step_refine_trigger') is True):
                     print(
                         "Trigger\t\t",
                         str(round(most_triggering_ranks[rank_position])) + "\t",
@@ -548,7 +548,7 @@ if (setup_steps.get('step_organize_sounds') is True):
         for iLeast in least_triggering_list:
             current_path = all_sound_files[np.char.find(all_sound_labels, iLeast) >= 0]
             with open(file_name, "a") as textfile:
-                if step_refine_neutral:
+                if (setup_steps.get('step_refine_neutral') is True):
                     print(
                         "Neutral\t\t",
                         str(round(least_triggering_ranks[rank_position])) + "\t",

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -62,9 +62,33 @@ if (setup_steps.get('step_refine_sound_list') is False) and (setup_steps.get('st
 if (setup_steps.get('step_select_sound_list') is False) and (setup_steps.get('step_organize_sounds') is True):
     raise Exception("Need to select sounds before you can organize them! Make sure Step_select_sound_list = True")
 
+# Error if participant number is already used, otherwise prep data file
+if (setup_steps.get('step_organize_sounds') is True):
+    # Make output file to save selections
+    data_dir = home_dir + os.sep + "Sound_Selections" + os.sep
+    if not os.path.isdir(data_dir):
+        os.makedirs(data_dir)
+    file_name = data_dir + participant + ".txt"
+
+    usable_file_name_found = False
+    while usable_file_name_found is False:
+        if os.path.isfile(file_name):
+            if participant == "TEST":
+                os.remove(file_name)
+                usable_file_name_found = True
+            else:
+                print("Sound Selections file for this participant already exists! Choose a different participant name.")
+                
+                participant = (
+                    setup_misosoupy.get_participant_id()
+                )  # choose a new participant id
+                file_name = data_dir + participant + ".txt"
+
+        else:
+            usable_file_name_found = True
+
 if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step_refine_sound_list') is True):
     from psychopy import visual
-    import psychopy_exit_out
     import psychopy_present_instructions
     
     setup_full_screen_choice = setup_screen.get('setup_full_screen_choice')
@@ -491,19 +515,6 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
     win.close()
 
 if (setup_steps.get('step_organize_sounds') is True):
-    # Make output file to save selections
-    data_dir = home_dir + os.sep + "Sound_Selections" + os.sep
-    if not os.path.isdir(data_dir):
-        os.makedirs(data_dir)
-    file_name = data_dir + participant + ".txt"
-    if os.path.isfile(file_name) and participant != "TEST":
-        if participant != "TEST":
-            raise Exception(
-                "Sound Selections file for this participant already exists! Choose a different participant name."
-            )
-        else:
-            os.remove(file_name)
-
     with open(file_name, "w") as textfile:
         if (setup_steps.get('step_refine_sound_list') is True):
             print(

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -42,6 +42,7 @@ path_to_assets = setup_misosoupy.get_path_to_assets()
 config_path = home_dir + os.sep + 'config.ini'
 [setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
 
+# Import sounds
 if (setup_steps.get('step_import_sound_list') is True):
     import import_sound_list
 
@@ -49,7 +50,17 @@ if (setup_steps.get('step_import_sound_list') is True):
         import_sound_list.function_import_sound_list(path_to_assets, source_sound_list)
     )  # 'naturalsounds165' sound_list.csv
 else:
-    raise Exception("Need sounds to select from!")
+    raise Exception("Need sounds to select from! Make sure Step_import_sound_list = True")
+
+# Error if setup step choices are incompatible
+if (setup_steps.get('step_select_sound_list') is False) and (setup_steps.get('step_select_trigger') is True or setup_steps.get('step_select_neutral') is True):
+    raise Exception("To select particular sounds (e.g., trigger, neutral), make sure Step_select_sound_list = True")
+if (setup_steps.get('step_select_sound_list') is False) and (setup_steps.get('step_refine_sound_list') is True):
+    raise Exception("Need to select sounds before you can refine them! Make sure Step_select_sound_list = True")
+if (setup_steps.get('step_refine_sound_list') is False) and (setup_steps.get('step_refine_trigger') is True or setup_steps.get('step_refine_neutral') is True):
+    raise Exception("To refine particular sounds (e.g., trigger, neutral), make sure Step_refine_sound_list = True")
+if (setup_steps.get('step_select_sound_list') is False) and (setup_steps.get('step_organize_sounds') is True):
+    raise Exception("Need to select sounds before you can organize them! Make sure Step_select_sound_list = True")
 
 if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step_refine_sound_list') is True):
     from psychopy import core, event, logging, visual

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -156,72 +156,23 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         instructions_general = instructions_general1 + instructions_general3 + instructions_general2 + instructions_general4
         psychopy_present_instructions.function_present_instructions(win, instructions_general, 1)
 
-        instructions1 = (
-            "First, please choose \nthe sounds you are \n\n triggered by."
-            + "\n\n\nIf none of these \nsounds are triggering, \ncontinue to the \nnext page."
-        )
-        instructions2 = "MOST\n\n\n\n\n\n"
         instructions_error = (
             "Please try that again.\n\nRemember, you must select at LEAST "
             + str(num_items_to_select)
             + " sounds."
         )
 
-        done_with_most_triggering = False
-        iPage = 0
-        page_seen = [False] * num_pages
-        most_triggering_list = []
-        most_triggering_list_all_pages = [
-            [0] * num_items_per_page
-        ] * num_pages  # initialize index with 0s
-        initial_squares = [0] * num_items_per_page  # choices from previous page
-        while iPage < num_pages:
-            instructions3 = "Page " + str(iPage + 1) + "/" + str(num_pages)
-            most_triggering_list_page, back_chosen_page = (
-                psychopy_present_item_list.function_present_item_list(
-                    unique_sound_labels,
-                    num_items_per_page,
-                    mean_length,
-                    setup_item_height,
-                    win,
-                    iPage,
-                    instructions1,
-                    instructions2,
-                    "firebrick",
-                    instructions3,
-                    initial_squares,
-                    most_triggering_list,
-                    done_with_most_triggering,
-                )
+        if (setup_steps.get('step_select_trigger') is True):
+            instructions1 = (
+                "First, please choose \nthe sounds you are \n\n triggered by."
+                + "\n\n\nIf none of these \nsounds are triggering, \ncontinue to the \nnext page."
             )
-            page_seen[iPage] = True
-            most_triggering_list_all_pages[iPage] = most_triggering_list_page
-
-            if back_chosen_page:  # if participant chooses back button
-                iPage -= 1
-                initial_squares = most_triggering_list_all_pages[iPage]
-            else:
-                iPage += 1
-                if iPage < num_pages and page_seen[iPage]:
-                    initial_squares = most_triggering_list_all_pages[iPage]
-                else:
-                    initial_squares = [0] * num_items_per_page
-
-        most_triggering_index_temp = np.array(most_triggering_list_all_pages)
-        most_triggering_index = (
-            most_triggering_index_temp.flatten()
-        )  # vectorizes to single column
-        for iItem in range(len(most_triggering_index)):
-            if most_triggering_index[iItem] == 1:
-                most_triggering_list.append(unique_sound_labels[iItem])
-
-        # check to make sure enough categories were chosen, if not redo
-        if len(most_triggering_list) < num_items_to_select:
-            psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
+            instructions2 = "MOST\n\n\n\n\n\n"
 
             done_with_most_triggering = False
             iPage = 0
             page_seen = [False] * num_pages
+            most_triggering_list = []
             most_triggering_list_all_pages = [
                 [0] * num_items_per_page
             ] * num_pages  # initialize index with 0s
@@ -262,12 +213,63 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
             most_triggering_index = (
                 most_triggering_index_temp.flatten()
             )  # vectorizes to single column
-            most_triggering_list = []
             for iItem in range(len(most_triggering_index)):
                 if most_triggering_index[iItem] == 1:
                     most_triggering_list.append(unique_sound_labels[iItem])
 
-        done_with_most_triggering = True
+            # check to make sure enough categories were chosen, if not redo
+            if len(most_triggering_list) < num_items_to_select:
+                psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
+
+                done_with_most_triggering = False
+                iPage = 0
+                page_seen = [False] * num_pages
+                most_triggering_list_all_pages = [
+                    [0] * num_items_per_page
+                ] * num_pages  # initialize index with 0s
+                initial_squares = [0] * num_items_per_page  # choices from previous page
+                while iPage < num_pages:
+                    instructions3 = "Page " + str(iPage + 1) + "/" + str(num_pages)
+                    most_triggering_list_page, back_chosen_page = (
+                        psychopy_present_item_list.function_present_item_list(
+                            unique_sound_labels,
+                            num_items_per_page,
+                            mean_length,
+                            setup_item_height,
+                            win,
+                            iPage,
+                            instructions1,
+                            instructions2,
+                            "firebrick",
+                            instructions3,
+                            initial_squares,
+                            most_triggering_list,
+                            done_with_most_triggering,
+                        )
+                    )
+                    page_seen[iPage] = True
+                    most_triggering_list_all_pages[iPage] = most_triggering_list_page
+
+                    if back_chosen_page:  # if participant chooses back button
+                        iPage -= 1
+                        initial_squares = most_triggering_list_all_pages[iPage]
+                    else:
+                        iPage += 1
+                        if iPage < num_pages and page_seen[iPage]:
+                            initial_squares = most_triggering_list_all_pages[iPage]
+                        else:
+                            initial_squares = [0] * num_items_per_page
+
+                most_triggering_index_temp = np.array(most_triggering_list_all_pages)
+                most_triggering_index = (
+                    most_triggering_index_temp.flatten()
+                )  # vectorizes to single column
+                most_triggering_list = []
+                for iItem in range(len(most_triggering_index)):
+                    if most_triggering_index[iItem] == 1:
+                        most_triggering_list.append(unique_sound_labels[iItem])
+
+            done_with_most_triggering = True
 
     if (setup_steps.get('step_refine_trigger') is True):
         import psychopy_refine_item_list
@@ -317,17 +319,26 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         refined_most_triggering_list = sorted(refined_most_triggering_list)
 
     if (setup_steps.get('step_select_neutral') is True):
-        instructions_break2 = (
-            "Next, you will repeat this process with sounds "
-            + "\nyou find the LEAST triggering or MOST NEUTRAL."
-        )
-        instructions6 = (
-            "Now, please choose \nthe sounds you \nfind most"
-            + "\n\n\n\nIf all of these sounds\nare triggering, \ncontinue to the \nnext page."
-        )
-        instructions7 = "\nNEUTRAL\n\n\n\n\n"
+        if (setup_steps.get('step_select_trigger') is False): #this is the only/first category participants select
+            instructions6 = (
+                "First, please choose \nthe sounds you \nfind most"
+                + "\n\n\n\nIf all of these sounds\nare triggering, \ncontinue to the \nnext page."
+            )
+            instructions7 = "\nNEUTRAL\n\n\n\n\n"
+            done_with_most_triggering = False
+            most_triggering_list = []
+        else:
+            instructions_break2 = (
+                "Next, you will repeat this process with sounds "
+                + "\nyou find the LEAST triggering or MOST NEUTRAL."
+            )
+            instructions6 = (
+                "Now, please choose \nthe sounds you \nfind most"
+                + "\n\n\n\nIf all of these sounds\nare triggering, \ncontinue to the \nnext page."
+            )
+            instructions7 = "\nNEUTRAL\n\n\n\n\n"
 
-        psychopy_present_instructions.function_present_instructions(win, instructions_break2, 2)
+            psychopy_present_instructions.function_present_instructions(win, instructions_break2, 2)
 
         iPage = 0
         page_seen = [False] * num_pages
@@ -428,7 +439,20 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
                     least_triggering_list.append(unique_sound_labels[iItem])
 
     if (setup_steps.get('step_refine_neutral') is True):
+        if (setup_steps.get('step_refine_trigger') is False): #haven't seen refinement instructions yet
+            import psychopy_refine_item_list
+            instructions_break1 = (
+                "Great! \n\nOn the next page, you will see the sounds you selected. "
+                + "\n\nPlease choose your TOP "
+                + str(num_items_to_select)
+                + " most neutral \nsounds from this list, "
+                + "and rank order them from \n1 (more neutral) to "
+                + str(num_items_to_select)
+                + " (less neutral)."
+            )
+            psychopy_present_instructions.function_present_instructions(win, instructions_break1, 2)
 
+        
         instructions8 = (
             "Please rank the \n\nsounds to you. \n\n1 = more neutral\n"
             + str(num_items_to_select)
@@ -464,7 +488,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
 
     instructions_done = "Done!"
     psychopy_present_instructions.function_present_instructions(win, instructions_done, 1)
-    psychopy_exit_out.function_exit_out(win) #win.close()
+    win.close()
 
 if (setup_steps.get('step_organize_sounds') is True):
     # Make output file to save selections

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -183,7 +183,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         instructions_error = (
             "Please try that again.\n\nRemember, you must select at LEAST "
             + str(num_items_to_select)
-            + " sounds."
+            + " sounds, if possible."
         )
 
         if (setup_steps.get('step_select_trigger') is True):
@@ -325,6 +325,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         refined_most_triggering_list = []
         [most_triggering_list_refined, most_triggering_ranks] = (
             psychopy_refine_item_list.function_present_refined_item_list(
+                num_items_to_select,
                 mean_length,
                 setup_item_height,
                 win,
@@ -411,8 +412,13 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
             if least_triggering_index[iItem] == 1:
                 least_triggering_list.append(unique_sound_labels[iItem])
 
-        # check to make sure enough categories were chosen, if not redo
-        if len(least_triggering_list) < num_items_to_select:
+        num_available_to_select = num_sound_labels - len(most_triggering_list)
+
+        # check to make sure enough categories were chosen, if not redo 
+        if num_available_to_select < num_items_to_select: # if there were less than X options to choose from
+            num_items_to_select = num_available_to_select
+            
+        if (len(least_triggering_list) < num_items_to_select): 
             psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
 
             iPage = 0
@@ -493,6 +499,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         refined_least_triggering_list = []
         [least_triggering_list_refined, least_triggering_ranks] = (
             psychopy_refine_item_list.function_present_refined_item_list(
+                num_items_to_select,
                 mean_length,
                 setup_item_height,
                 win,

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -6,11 +6,9 @@ Created on Sat Jun  8 12:02:55 2024
 
 THINGS TO STILL ADD (AUG 23 2024):
 
-    Option to set minimum required sounds (current default: 5 per category)
-    Option to change instructions?
-    Option to change colors
+    Option to change colors?
     Option to select sounds without needing psychopy?
-
+    Option to query available sound lists and/or specify in config?
 
 """
 

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -101,104 +101,12 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
     else:
         setup_item_height = 0.085
 
-    def function_exit_out():
-        """Safely exit out of presentation, closing window and flushing log."""
-
-        logging.flush()
-        win.close()
-        core.quit()
-
-    def function_present_instructions(instruction_text, wait_time):
-        """Present instruction text onscreen using PsychoPy.
-
-        Parameters
-        ----------
-        instruction_text : str
-            Text to display.
-        wait_time : int
-            Time (in seconds) to pause before CONTINUE button is displayed.
-        """
-
-        # Prep instructions
-        stim_text_instruction1 = visual.TextStim(
-            win,
-            text=instruction_text,
-            pos=(0, 0),
-            color=setup_text_color,
-            height=0.09,
-            wrapWidth=6,
-        )
-        # Prep Continue Button
-        stim_text_continue = visual.TextStim(
-            win,
-            text="Click here to continue",
-            pos=(0.7, -0.85),
-            color=setup_screen_color,
-            height=0.08,
-        )
-        stim_shape_exit = visual.ShapeStim(
-            win,
-            vertices=((-0.5, -0.3), (-0.5, 0.3), (0.5, 0.3), (0.5, -0.3)),
-            pos=(1, 1),
-            size=(0.35, 0.35),
-            opacity=100,
-            fillColor=setup_screen_color,
-            lineColor=None,
-            lineWidth=4.0,
-            name="stim_shape_exit",
-        )
-        stim_shape_continue = stim_shape_exit
-
-        mouse = event.Mouse(win=win, visible=True)
-        mouse.clickReset()
-        event.clearEvents()
-
-        continue_chosen = False
-        stim_text_instruction1.draw()
-        stim_shape_continue.draw()
-        stim_text_continue.draw()
-        stim_shape_exit.draw()
-        win.flip()
-        core.wait(wait_time)
-        while continue_chosen is False:
-            stim_text_instruction1.draw()
-            stim_shape_continue.draw()
-            stim_text_continue.draw()
-            stim_shape_exit.draw()
-            win.flip()
-
-            if mouse.isPressedIn(stim_shape_exit):
-                function_exit_out()
-
-            # Make Continue Button visible after 3 seconds
-            stim_shape_continue = visual.ShapeStim(
-                win,
-                vertices=((-0.5, -0.3), (-0.5, 0.3), (0.5, 0.3), (0.5, -0.3)),
-                pos=(0.7, -0.85),
-                size=(0.45, 0.2),
-                opacity=100,
-                fillColor=setup_continue_shape_color,
-                lineColor=setup_shape_line_color,
-                lineWidth=4.0,
-                name="stim_shape_continue",
-            )
-            stim_text_continue = visual.TextStim(
-                win,
-                text="CONTINUE",
-                pos=(0.7, -0.85),
-                color=setup_text_color,
-                height=0.08,
-            )
-
-            if mouse.isPressedIn(stim_shape_continue):
-                stim_text_instruction1.draw()
-                stim_shape_continue.draw()
-                stim_text_continue.draw()
-                win.flip()
-                continue_chosen = True
-
+    
+    # Start sound selection process
     if (setup_steps.get('step_select_trigger') is True):
         import psychopy_present_item_list
+        import psychopy_exit_out
+        import psychopy_present_instructions
 
         instructions_general = (
             "In this experiment, you will listen to sounds."
@@ -210,7 +118,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
             + "\n\nThere will be 5 pages for each prompt (most and least). "
             + "\nTry to choose AT LEAST 4-5 sounds for each prompt."
         )
-        function_present_instructions(instructions_general, 1)
+        psychopy_present_instructions.function_present_instructions(win, instructions_general, 1)
 
         instructions1 = (
             "First, please choose \nthe sounds you are \n\n triggered by."
@@ -271,7 +179,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
 
         # check to make sure enough categories were chosen, if not redo
         if len(most_triggering_list) < 5:
-            function_present_instructions(instructions_error, 1)
+            psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
 
             done_with_most_triggering = False
             iPage = 0
@@ -338,7 +246,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         )
         instructions5 = "TOP 5\n\n\n\n\n\n\n\n\n\n"
 
-        function_present_instructions(instructions_break1, 2)
+        psychopy_present_instructions.function_present_instructions(win, instructions_break1, 2)
 
         refined_most_triggering_list = []
         [most_triggering_list_refined, most_triggering_ranks] = (
@@ -371,7 +279,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         )
         instructions7 = "\nNEUTRAL\n\n\n\n\n"
 
-        function_present_instructions(instructions_break2, 2)
+        psychopy_present_instructions.function_present_instructions(win, instructions_break2, 2)
 
         iPage = 0
         page_seen = [False] * num_pages
@@ -422,7 +330,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
 
         # check to make sure enough categories were chosen, if not redo
         if len(least_triggering_list) < 5:
-            function_present_instructions(instructions_error, 1)
+            psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
 
             iPage = 0
             page_seen = [False] * num_pages
@@ -500,8 +408,8 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         refined_least_triggering_list = sorted(refined_least_triggering_list)
 
     instructions_done = "Done!"
-    function_present_instructions(instructions_done, 1)
-    win.close()
+    psychopy_present_instructions.function_present_instructions(win, instructions_done, 1)
+    psychopy_exit_out.function_exit_out(win) #win.close()
 
 if (setup_steps.get('step_organize_sounds') is True):
     # Make output file to save selections

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -25,13 +25,6 @@ import numpy as np
 import setup_misosoupy
 
 # Set up preferences ################
-step_import_sound_list = True
-step_select_sound_list = True
-step_select_trigger, step_select_neutral = True, True
-step_refine_sound_list = True
-step_refine_trigger, step_refine_neutral = True, True
-step_organize_sounds = True
-
 global home_dir
 home_dir = setup_misosoupy.get_home_dir()  # creates global variable "home_dir"
 global participant
@@ -45,7 +38,11 @@ source_sound_list = (
 
 path_to_assets = setup_misosoupy.get_path_to_assets()
 
-if step_import_sound_list:
+# Read config file
+config_path = home_dir + os.sep + 'config.ini'
+[setup_steps, setup_screen]=setup_misosoupy.parse_config_file(config_path)
+
+if (setup_steps.get('step_import_sound_list') is True):
     import import_sound_list
 
     [all_sound_files, all_sound_labels, unique_sound_labels] = (
@@ -54,21 +51,21 @@ if step_import_sound_list:
 else:
     raise Exception("Need sounds to select from!")
 
-if step_select_sound_list or step_refine_sound_list:
+if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step_refine_sound_list') is True):
     from psychopy import core, event, logging, visual
 
-    setup_full_screen_choice = True  # make True during actual task
-    setup_which_screen = 0  # 2 #make 1 when only 1 monitor
-    setup_screen_size = [1920, 1080]  # make [2048, 1152]
-    setup_screen_color = "lightgray"
-    setup_text_color = "black"
-    setup_continue_shape_color = "gray"
-    setup_shape_line_color = "black"
-    setup_square_outline_size = 0.12
-    setup_square_size = 0.1
-    num_columns_per_page = 2
-    num_items_per_column = 10
-    pause_time = 2  # stay on item screen for 2s before skipping
+    setup_full_screen_choice = setup_screen.get('setup_full_screen_choice')
+    setup_which_screen = setup_screen.get('setup_which_screen')
+    #setup_screen_size = setup_screen.get('setup_screen_size')
+    setup_screen_color = setup_screen.get('setup_screen_color')
+    setup_text_color = setup_screen.get('setup_text_color')
+    setup_continue_shape_color = setup_screen.get('setup_continue_shape_color')
+    setup_shape_line_color = setup_screen.get('setup_shape_line_color')
+    setup_square_outline_size = setup_screen.get('setup_square_outline_size')
+    setup_square_size = setup_screen.get('setup_square_size')
+    num_columns_per_page = setup_screen.get('num_columns_per_page')
+    num_items_per_column = setup_screen.get('num_items_per_column')
+    pause_time = setup_screen.get('pause_time')
 
     num_sound_labels = len(unique_sound_labels)
     num_items_per_page = num_items_per_column * num_columns_per_page
@@ -76,7 +73,6 @@ if step_select_sound_list or step_refine_sound_list:
 
     # --- Setup the Window ---
     win = visual.Window(
-        size=setup_screen_size,
         fullscr=setup_full_screen_choice,
         screen=setup_which_screen,
         color=setup_screen_color,
@@ -190,7 +186,7 @@ if step_select_sound_list or step_refine_sound_list:
                 win.flip()
                 continue_chosen = True
 
-    if step_select_trigger:
+    if (setup_steps.get('step_select_trigger') is True):
         import psychopy_present_item_list
 
         instructions_general = (
@@ -227,20 +223,11 @@ if step_select_sound_list or step_refine_sound_list:
             most_triggering_list_page, back_chosen_page = (
                 psychopy_present_item_list.function_present_item_list(
                     unique_sound_labels,
-                    num_columns_per_page,
-                    num_items_per_column,
                     num_items_per_page,
                     mean_length,
                     setup_item_height,
-                    setup_square_outline_size,
-                    setup_square_size,
-                    setup_text_color,
-                    setup_screen_color,
-                    setup_continue_shape_color,
-                    setup_shape_line_color,
                     win,
                     iPage,
-                    pause_time,
                     instructions1,
                     instructions2,
                     "firebrick",
@@ -287,20 +274,11 @@ if step_select_sound_list or step_refine_sound_list:
                 most_triggering_list_page, back_chosen_page = (
                     psychopy_present_item_list.function_present_item_list(
                         unique_sound_labels,
-                        num_columns_per_page,
-                        num_items_per_column,
                         num_items_per_page,
                         mean_length,
                         setup_item_height,
-                        setup_square_outline_size,
-                        setup_square_size,
-                        setup_text_color,
-                        setup_screen_color,
-                        setup_continue_shape_color,
-                        setup_shape_line_color,
                         win,
                         iPage,
-                        pause_time,
                         instructions1,
                         instructions2,
                         "firebrick",
@@ -334,7 +312,7 @@ if step_select_sound_list or step_refine_sound_list:
 
         done_with_most_triggering = True
 
-    if step_refine_trigger:
+    if (setup_steps.get('step_refine_trigger') is True):
         import psychopy_refine_item_list
 
         instructions_break1 = (
@@ -349,19 +327,13 @@ if step_select_sound_list or step_refine_sound_list:
         )
         instructions5 = "TOP 5\n\n\n\n\n\n\n\n\n\n"
 
-        function_present_instructions(instructions_break1, 0)
+        function_present_instructions(instructions_break1, 2)
 
         refined_most_triggering_list = []
         [most_triggering_list_refined, most_triggering_ranks] = (
             psychopy_refine_item_list.function_present_refined_item_list(
                 mean_length,
                 setup_item_height,
-                setup_square_outline_size,
-                setup_square_size,
-                setup_text_color,
-                setup_screen_color,
-                setup_continue_shape_color,
-                setup_shape_line_color,
                 win,
                 most_triggering_list,
                 instructions4,
@@ -377,7 +349,7 @@ if step_select_sound_list or step_refine_sound_list:
 
         refined_most_triggering_list = sorted(refined_most_triggering_list)
 
-    if step_select_neutral:
+    if (setup_steps.get('step_select_neutral') is True):
         instructions_break2 = (
             "Next, you will repeat this process with sounds "
             + "\nyou find the LEAST triggering or MOST NEUTRAL."
@@ -388,7 +360,7 @@ if step_select_sound_list or step_refine_sound_list:
         )
         instructions7 = "\nNEUTRAL\n\n\n\n\n"
 
-        function_present_instructions(instructions_break2, 0)
+        function_present_instructions(instructions_break2, 2)
 
         iPage = 0
         page_seen = [False] * num_pages
@@ -401,20 +373,11 @@ if step_select_sound_list or step_refine_sound_list:
             least_triggering_list_page, back_chosen_page = (
                 psychopy_present_item_list.function_present_item_list(
                     unique_sound_labels,
-                    num_columns_per_page,
-                    num_items_per_column,
                     num_items_per_page,
                     mean_length,
                     setup_item_height,
-                    setup_square_outline_size,
-                    setup_square_size,
-                    setup_text_color,
-                    setup_screen_color,
-                    setup_continue_shape_color,
-                    setup_shape_line_color,
                     win,
                     iPage,
-                    pause_time,
                     instructions6,
                     instructions7,
                     "green",
@@ -461,20 +424,11 @@ if step_select_sound_list or step_refine_sound_list:
                 least_triggering_list_page, back_chosen_page = (
                     psychopy_present_item_list.function_present_item_list(
                         unique_sound_labels,
-                        num_columns_per_page,
-                        num_items_per_column,
                         num_items_per_page,
                         mean_length,
                         setup_item_height,
-                        setup_square_outline_size,
-                        setup_square_size,
-                        setup_text_color,
-                        setup_screen_color,
-                        setup_continue_shape_color,
-                        setup_shape_line_color,
                         win,
                         iPage,
-                        pause_time,
                         instructions6,
                         instructions7,
                         "green",
@@ -506,7 +460,7 @@ if step_select_sound_list or step_refine_sound_list:
                 if least_triggering_index[iItem] == 1:
                     least_triggering_list.append(unique_sound_labels[iItem])
 
-    if step_refine_neutral:
+    if (setup_steps.get('step_refine_neutral') is True):
 
         instructions8 = (
             "Please rank the \n\nsounds to you. \n\n1 = more neutral\n5 = less neutral "
@@ -519,12 +473,6 @@ if step_select_sound_list or step_refine_sound_list:
             psychopy_refine_item_list.function_present_refined_item_list(
                 mean_length,
                 setup_item_height,
-                setup_square_outline_size,
-                setup_square_size,
-                setup_text_color,
-                setup_screen_color,
-                setup_continue_shape_color,
-                setup_shape_line_color,
                 win,
                 least_triggering_list,
                 instructions8,
@@ -541,10 +489,10 @@ if step_select_sound_list or step_refine_sound_list:
         refined_least_triggering_list = sorted(refined_least_triggering_list)
 
     instructions_done = "Done!"
-    function_present_instructions(instructions_done, 0)
+    function_present_instructions(instructions_done, 1)
     win.close()
 
-if step_organize_sounds:
+if (setup_steps.get('step_organize_sounds') is True):
     # Make output file to save selections
     data_dir = home_dir + os.sep + "Sound_Selections" + os.sep
     if not os.path.isdir(data_dir):
@@ -571,7 +519,7 @@ if step_organize_sounds:
             print("SOUND_TYPE\t", "SOUND_LABEL\t\t", "FILE_NAME(S)", file=textfile)
 
     # Cycle through selections to grab path names
-    if step_select_trigger:
+    if (setup_steps.get('step_select_trigger') is True):
         most_trigger_paths = []
         rank_position = 0
         for iMost in most_triggering_list:
@@ -594,7 +542,7 @@ if step_organize_sounds:
                     )
             rank_position += 1
 
-    if step_select_neutral:
+    if (setup_steps.get('step_select_neutral') is True):
         least_trigger_paths = []
         rank_position = 0
         for iLeast in least_triggering_list:

--- a/src/misosoupy/run_misosoupy.py
+++ b/src/misosoupy/run_misosoupy.py
@@ -63,8 +63,10 @@ if (setup_steps.get('step_select_sound_list') is False) and (setup_steps.get('st
     raise Exception("Need to select sounds before you can organize them! Make sure Step_select_sound_list = True")
 
 if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step_refine_sound_list') is True):
-    from psychopy import core, event, logging, visual
-
+    from psychopy import visual
+    import psychopy_exit_out
+    import psychopy_present_instructions
+    
     setup_full_screen_choice = setup_screen.get('setup_full_screen_choice')
     setup_which_screen = setup_screen.get('setup_which_screen')
     #setup_screen_size = setup_screen.get('setup_screen_size')
@@ -74,6 +76,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
     setup_shape_line_color = setup_screen.get('setup_shape_line_color')
     setup_square_outline_size = setup_screen.get('setup_square_outline_size')
     setup_square_size = setup_screen.get('setup_square_size')
+    num_items_to_select = setup_screen.get('num_items_to_select')
     num_columns_per_page = setup_screen.get('num_columns_per_page')
     num_items_per_column = setup_screen.get('num_items_per_column')
     pause_time = setup_screen.get('pause_time')
@@ -103,21 +106,54 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
 
     
     # Start sound selection process
-    if (setup_steps.get('step_select_trigger') is True):
+    if (setup_steps.get('step_select_sound_list') is True):
         import psychopy_present_item_list
-        import psychopy_exit_out
-        import psychopy_present_instructions
-
-        instructions_general = (
+        
+        instructions_general1 = (
             "In this experiment, you will listen to sounds."
             + "\nIt is important that we use the most effective sounds for each participant."
-            + "\n\nOn the next pages, you will see the names of sounds. \nPlease select the sounds "
-            + "that you find \nthe MOST triggering (e.g., bothersome, unpleasant) "
-            + "and \nthe LEAST triggering (e.g., neutral, neither pleasant nor unpleasant)."
-            + "\nDo this by clicking the box next to the sound name."
-            + "\n\nThere will be 5 pages for each prompt (most and least). "
-            + "\nTry to choose AT LEAST 4-5 sounds for each prompt."
+            + "\n\nOn the next pages, you will see the names of sounds."
         )
+        instructions_general2 = ("\nDo this by clicking the box next to the sound name.")
+        if (setup_steps.get('step_select_trigger') is True) and (setup_steps.get('step_select_neutral') is True):
+            instructions_general3 = (
+                "\nPlease select the sounds that you find"
+                + "\nthe MOST triggering (e.g., bothersome, unpleasant) "
+                + "and \nthe LEAST triggering (e.g., neutral, neither pleasant nor unpleasant)."
+            )
+            instructions_general4 = (
+                "\n\nThere will be "
+                + str(num_pages)
+                + " page(s) for each prompt (most and least). "
+                + "\nTry to choose AT LEAST "
+                + str(num_items_to_select)
+                + " sounds for each prompt."
+            )
+        elif (setup_steps.get('step_select_trigger') is True) and (setup_steps.get('step_select_neutral') is False):
+            instructions_general3 = (
+                "\nPlease select the sounds that you find"
+                + "\nthe MOST triggering (e.g., bothersome, unpleasant). "
+            )
+            instructions_general4 = (
+                "\n\nThere will be "
+                + str(num_pages)
+                + " page(s).\nTry to choose AT LEAST "
+                + str(num_items_to_select)
+                + " sounds."
+            )
+        elif (setup_steps.get('step_select_trigger') is False) and (setup_steps.get('step_select_neutral') is True):
+            instructions_general3 = (
+                "\nPlease select the sounds that you find"
+                + "\nthe LEAST triggering (e.g., neutral, neither pleasant nor unpleasant)."
+            )
+            instructions_general4 = (
+                "\n\nThere will be "
+                + str(num_pages)
+                + " page(s).\nTry to choose AT LEAST "
+                + str(num_items_to_select)
+                + " sounds."
+            )
+        instructions_general = instructions_general1 + instructions_general3 + instructions_general2 + instructions_general4
         psychopy_present_instructions.function_present_instructions(win, instructions_general, 1)
 
         instructions1 = (
@@ -126,7 +162,9 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
         )
         instructions2 = "MOST\n\n\n\n\n\n"
         instructions_error = (
-            "Please try that again.\n\nRemember, you must select at LEAST 5 sounds."
+            "Please try that again.\n\nRemember, you must select at LEAST "
+            + str(num_items_to_select)
+            + " sounds."
         )
 
         done_with_most_triggering = False
@@ -178,7 +216,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
                 most_triggering_list.append(unique_sound_labels[iItem])
 
         # check to make sure enough categories were chosen, if not redo
-        if len(most_triggering_list) < 5:
+        if len(most_triggering_list) < num_items_to_select:
             psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
 
             done_with_most_triggering = False
@@ -236,15 +274,25 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
 
         instructions_break1 = (
             "Great! \n\nOn the next page, you will see the sounds you selected. "
-            + "\n\nPlease choose your TOP 5 most triggering \nsounds from this list, "
-            + "and rank order them from \n1 (more triggering) to 5 (less triggering)."
+            + "\n\nPlease choose your TOP "
+            + str(num_items_to_select)
+            + " most triggering \nsounds from this list, "
+            + "and rank order them from \n1 (more triggering) to "
+            + str(num_items_to_select)
+            + " (less triggering)."
         )
         instructions4 = (
             "Please rank the \n\nsounds you \nare triggered by. "
-            + "\n\n1 = more triggering\n5 = less triggering \n\n"
-            + "Once you have \nselected your top 5, \ncontinue to the \nnext page."
+            + "\n\n1 = more triggering\n"
+            + str(num_items_to_select)
+            + " = less triggering \n\n"
+            + "Once you have \nselected your top "
+            + str(num_items_to_select)
+            +", \ncontinue to the \nnext page."
         )
-        instructions5 = "TOP 5\n\n\n\n\n\n\n\n\n\n"
+        instructions5 = ("TOP " 
+                         + str(num_items_to_select)
+                         +"\n\n\n\n\n\n\n\n\n\n")
 
         psychopy_present_instructions.function_present_instructions(win, instructions_break1, 2)
 
@@ -329,7 +377,7 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
                 least_triggering_list.append(unique_sound_labels[iItem])
 
         # check to make sure enough categories were chosen, if not redo
-        if len(least_triggering_list) < 5:
+        if len(least_triggering_list) < num_items_to_select:
             psychopy_present_instructions.function_present_instructions(win, instructions_error, 1)
 
             iPage = 0
@@ -382,10 +430,17 @@ if (setup_steps.get('step_select_sound_list') is True) or (setup_steps.get('step
     if (setup_steps.get('step_refine_neutral') is True):
 
         instructions8 = (
-            "Please rank the \n\nsounds to you. \n\n1 = more neutral\n5 = less neutral "
-            + "\n\n\nOnce you have \nselected your top 5, \ncontinue to the \nnext page."
+            "Please rank the \n\nsounds to you. \n\n1 = more neutral\n"
+            + str(num_items_to_select)
+            + " = less neutral "
+            + "\n\n\nOnce you have \nselected your top "
+            + str(num_items_to_select)
+            + ", \ncontinue to the \nnext page."
         )
-        instructions9 = "5 MOST NEUTRAL\n\n\n\n\n\n\n\n\n\n"
+        instructions9 = (
+            str(num_items_to_select)
+            + " MOST NEUTRAL\n\n\n\n\n\n\n\n\n\n"
+        )
 
         refined_least_triggering_list = []
         [least_triggering_list_refined, least_triggering_ranks] = (

--- a/src/misosoupy/setup_misosoupy.py
+++ b/src/misosoupy/setup_misosoupy.py
@@ -103,7 +103,7 @@ def parse_config_file(config_path):
         else:    
             try:
                 screen_parameters[key] = float(value) 
-            except:
+            except ValueError:
                 screen_parameters[key] = value
 
     return steps_to_complete, screen_parameters

--- a/src/misosoupy/setup_misosoupy.py
+++ b/src/misosoupy/setup_misosoupy.py
@@ -14,6 +14,8 @@ from warnings import warn
 
 import pkg_resources
 
+import configparser
+
 
 # Ensure that relative paths start from the same directory as this script
 def get_home_dir():
@@ -76,3 +78,32 @@ def get_path_to_assets():
         return Path(resources.files(misosoupy) / "assets")
     else:
         return Path(pkg_resources.resource_filename("misosoupy", "assets"))
+
+# Read in config file
+# (code from https://medium.com/@lelambonzo/simplifying-configuration-file-parsing-in-python-ef8e2144b3b3)
+def parse_config_file(config_path): 
+    config = configparser.ConfigParser()
+    config.read(config_path)
+
+    steps_to_complete = {}
+    for key, value in config['STEPS'].items():
+        if value.lower() in 'true':
+            steps_to_complete[key] = True
+        elif value.lower() in 'false':
+            steps_to_complete[key] = False
+
+    screen_parameters = {}
+    for key, value in config['SCREEN'].items():
+        if value.isdigit():
+            screen_parameters[key] = int(value)
+        elif value.lower() in 'true':
+            screen_parameters[key] = True
+        elif value.lower() in 'false':
+            screen_parameters[key] = False
+        else:    
+            try:
+                screen_parameters[key] = float(value) 
+            except:
+                screen_parameters[key] = value
+
+    return steps_to_complete, screen_parameters


### PR DESCRIPTION
Changes:
- add config.ini with comments/defaults for each choice
- add function to parse config file in setup_misosoupy
- call config function in run_misosoupy, psychopy_present_item_list, and psychopy_refine_item_list
- remove redundant input arguments from functions, shorten docstrings

I have a list of optimizations I'm still working on (in addition to documenting sample usage), but I want to make sure this doesn't blow up on your end before I keep going.