### PR TITLE
More updates to README

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,10 +17,12 @@ Added
 Changed
 ~~~~~~~
 
+- Minor change to contributing guide (removed note).
+
 Fixed
 ~~~~~
 
-- Updated badges in README.
+- Updated badges and links in README.
 
 Removed
 ~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,8 +12,7 @@ If you are new to using `git <https://git-scm.com>`__ or have never
 collaborated in a project previously, please have a look at
 `contribution-guide.org <http://www.contribution-guide.org/>`__. Other
 resources are also listed in the excellent `guide created by
-FreeCodeCamp <https://github.com/freecodecamp/how-to-contribute-to-open-source>`__
- [1]_.
+FreeCodeCamp <https://github.com/freecodecamp/how-to-contribute-to-open-source>`__.
 
 Please notice, all users and contributors are expected to be **open,
 considerate, reasonable, and respectful**. When in doubt, `Python
@@ -284,10 +283,3 @@ used to release a new version for misosoupy:
    may have been accidentally included.
 6. Run tox -e publish – –repository pypi and check that everything was
    uploaded to `PyPI <https://pypi.org/>`__ correctly.
-
-.. [1]
-   Even though, these resources focus on open source projects and
-   communities, the general ideas behind collaborating with other
-   developers to collectively create software are general and can be
-   applied to all sorts of environments, including private companies and
-   proprietary code bases.

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 .. These are examples of badges you might want to add to your README:
    please update the URLs accordingly
 
-.. image:: https://readthedocs.org/projects/misosoupy/badge/?version=latest
-    :alt: ReadTheDocs
-    :target: https://misosoupy.readthedocs.io/en/stable/
 .. image:: https://img.shields.io/pypi/v/misosoupy.svg
     :alt: PyPI-Server
     :target: https://pypi.org/project/misosoupy/
@@ -177,4 +174,4 @@ It is a good idea to update the hooks to the latest version::
     pre-commit autoupdate
 
 .. _pre-commit: https://pre-commit.com/
-.. _guide: https://misosoupy.readthedocs.io/en/stable/contributing.html
+.. _guide: https://github.com/miso-sound/misosoupy/blob/dev/CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,6 @@ Examples
 *Example: Instructions for selecting both Trigger and Neutral sounds, at least 5 in each.*
 
 .. figure:: ./docs/media/instructions3.png
-   :scale: 50 %
    :width: 100 px
 
 *Example: Instructions for selecting only Trigger sounds, at least 4.*

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Examples
 *Example: Instructions for selecting both Trigger and Neutral sounds, at least 5 in each.*
 
 .. figure:: ./docs/media/instructions3.png
-   :width: 100 px
+   :width: 500 px
 
 *Example: Instructions for selecting only Trigger sounds, at least 4.*
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,6 @@ Examples
 *Example: Instructions for selecting both Trigger and Neutral sounds, at least 5 in each.*
 
 .. figure:: ./docs/media/instructions3.png
-   :width: 500 px
 
 *Example: Instructions for selecting only Trigger sounds, at least 4.*
 


### PR DESCRIPTION
This PR removes the scaling of an image in the README [which seemed to cause issues publishing on PyPI](https://github.com/miso-sound/misosoupy/issues/25), as well as removes the links to the readthedocs page [which currently isn't working](https://github.com/miso-sound/misosoupy/issues/24).

I also removed a note in the contributing guide that I just noticed and thought was unnecessary.